### PR TITLE
[BUGFIXING] child discount codes can be used more than once

### DIFF
--- a/pmpro-group-discount-codes.php
+++ b/pmpro-group-discount-codes.php
@@ -276,12 +276,17 @@ add_filter( 'pmpro_discount_code_level', 'pmpro_groupcodes_pmpro_discount_code_l
  *
  * @since 0.4
  *
- * @param int $discount_code_id The discount code ID used.
  * @param int $user_id The user ID.
- * @param int $order_id The order ID.
+ * @param MemberOrder $order The order object.
  */
-function pmpro_groupcodes_pmpro_discount_code_used( $discount_code_id, $user_id, $order_id ) {
+function pmpro_groupcodes_pmpro_discount_code_used( $user_id, $order ) {
 	global $wpdb;
+
+	// Get the order ID.
+	$order_id = $order->id;
+
+	// Get the discount code ID.
+	$discount_code_id = $order->discount_code_id;
 
 	// If $discount_code_id is not empty, then a legitemate discount code was used. Bail.
 	if ( ! empty( $discount_code_id ) ) {
@@ -326,7 +331,7 @@ function pmpro_groupcodes_pmpro_discount_code_used( $discount_code_id, $user_id,
 	$order->notes .= "\n---\n{GROUPCODE:" . $group_code->code . "}\n---\n";
 	$order->saveOrder();
 }
-add_action( 'pmpro_discount_code_used', 'pmpro_groupcodes_pmpro_discount_code_used', 10, 3 );
+add_action( 'pmpro_after_checkout', 'pmpro_groupcodes_pmpro_discount_code_used', 10, 2 );
 
 /**
  * Filter discount code when showing invoice.


### PR DESCRIPTION
 * Run pmpro_groupcodes_pmpro_discount_code_used callback in pmpro_after_checkout hook instead
 
 
<img width="1310" alt="image" src="https://github.com/user-attachments/assets/708b4eac-ed7b-4266-9610-55ca9ae3cd4f">
<img width="1319" alt="image" src="https://github.com/user-attachments/assets/b526fc47-f090-4b56-9702-e4732e0351d7">


### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-courses/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-courses/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #14 .

### How to test the changes in this Pull Request:

Follow steps described in the linked issue above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
